### PR TITLE
Push to version 0.0.3 with several fixes

### DIFF
--- a/nemo/graph.py
+++ b/nemo/graph.py
@@ -284,5 +284,5 @@ class DeployGraph(object):
                 except IndexError:
                     break
             # forward-track route to node
-            supernodes[self.non_unique_names_dict[target.key]] = route[::-1]
+            supernodes[self.non_unique_names_dict[target.key]] = {'supernode': route[::-1], 'previous': self.non_unique_names_dict[curr.key]}
         return supernodes

--- a/nemo/quant/pact.py
+++ b/nemo/quant/pact.py
@@ -640,7 +640,7 @@ class PACT_QuantizedBatchNorm2d(torch.nn.Module):
 
     """
 
-    def __init__(self, precision=None, kappa=None, lamda=None, nb_channels=1, statistics_only=False):
+    def __init__(self, precision=None, kappa=None, lamda=None, nb_channels=1, statistics_only=False, dimensions=2):
         r"""Constructor.
 
         :param precision: instance defining the current quantization level (default `None`).
@@ -653,6 +653,8 @@ class PACT_QuantizedBatchNorm2d(torch.nn.Module):
         :type  nb_channels: int
         :param statistics_only: initialization value of `statistics_only` member.
         :type  statistics_only: bool
+        :param dimensions: number of BatchNorm dimensions (default 2).
+        :type  dimensions: int
 
         """
 
@@ -665,14 +667,18 @@ class PACT_QuantizedBatchNorm2d(torch.nn.Module):
             self.precision_lamda = precision
         device = 'cuda' if torch.cuda.is_available() else 'cpu'
 
+        if dimensions == 2:
+            param_shape = lambda n : (1, n, 1, 1)
+        elif dimensions == 1:
+            param_shape = lambda n : (n,)
         if kappa is None:
-            self.kappa = torch.nn.Parameter(torch.zeros(1,nb_channels,1,1).to(device), requires_grad=False)
+            self.kappa = torch.nn.Parameter(torch.zeros(*param_shape(nb_channels)).to(device), requires_grad=False)
         else:
-            self.kappa = torch.nn.Parameter(kappa.to(device), requires_grad=False).reshape((1,kappa.shape[0],1,1))
+            self.kappa = torch.nn.Parameter(kappa.to(device), requires_grad=False).reshape(param_shape(kappa.shape[0]))
         if lamda is None:
-            self.lamda = torch.nn.Parameter(torch.zeros(1,nb_channels,1,1).to(device), requires_grad=False)
+            self.lamda = torch.nn.Parameter(torch.zeros(*param_shape(nb_channels)).to(device), requires_grad=False)
         else:
-            self.lamda = torch.nn.Parameter(lamda.to(device), requires_grad=False).reshape((1,lamda.shape[0],1,1))
+            self.lamda = torch.nn.Parameter(lamda.to(device), requires_grad=False).reshape(param_shape(lamda.shape[0]))
 
         self.statistics_only = statistics_only
 

--- a/nemo/transf/bn.py
+++ b/nemo/transf/bn.py
@@ -79,7 +79,7 @@ def _unfreeze_bn(self):
         if m.__class__.__name__ == "BatchNorm2d":
             m.train()
 
-def _fold_bn_pact(self, bn_dict={}, bn_inv_dict={}, eps=None, phi_inv=0.):
+def _fold_bn_pact(self, bn_dict={}, bn_inv_dict={}, eps=None, phi_inv=0., reset_alpha=True):
     r"""Performs batch-normalization folding following the algorithm presented in
     https://arxiv.org/abs/1905.04166. It performs both normal folding and inverse
     folding using two separate dictionaries `bn_dict` and `bn_inv_dict`.
@@ -94,6 +94,8 @@ def _fold_bn_pact(self, bn_dict={}, bn_inv_dict={}, eps=None, phi_inv=0.):
     :type  eps: float
     :param phi_inv: parameter added to `gamma` in inverse folding for better numerical stability (default 0).
     :type  phi_inv: float
+    :param reset_alpha: if True, reset the clipping parameters of weights (default True).
+    :type  reset_alpha: bool
 
     """
 
@@ -196,6 +198,8 @@ def _fold_bn_pact(self, bn_dict={}, bn_inv_dict={}, eps=None, phi_inv=0.):
             m.bias.data[:] = 0.
             m.running_mean.data[:] = 0.
             m.running_var.data[:] = (1. - eps)**2
+    if reset_alpha:
+        self.reset_alpha_weights()
 
 def _threshold_folding_pact(self, act_dict):
     r"""Performs the folding of batch-normalization layers into threshold-based

--- a/nemo/transf/common.py
+++ b/nemo/transf/common.py
@@ -30,7 +30,7 @@ import math
 import torchvision.models
 import re
 
-__all__ = [ "reshape_before", "reshape_after", "weight_range", "onnx_name_2_pytorch_name", "get_bn_dict_from_supernodes" ]
+__all__ = [ "reshape_before", "reshape_after", "weight_range", "onnx_name_2_pytorch_name", "get_bn_dict_from_supernodes", "get_equalize_dict_from_supernodes" ]
 
 def reshape_before(m, s):
     if   m.__class__.__name__ == "PACT_Conv2d":
@@ -82,12 +82,36 @@ def onnx_name_2_pytorch_name(name):
     name_parts = [part[1:-1] for part in name_parts]
     return '.'.join(name_parts)
  
+def get_equalize_dict_from_supernodes(net):
+    eq_dict = {}
+    act_dict = {}
+    # check all supernodes for ACT and CONV layers
+    lin = {}
+    act = {}
+    prev = {}
+    for k,ssn in net.graph.get_supernodes().items():
+        for n in ssn['supernode']:
+             if isinstance(n[1], PACT_Conv2d) or \
+                isinstance(n[1], PACT_Conv1d) or \
+                isinstance(n[1], PACT_Linear):
+                 lin[k]  = n[0]
+        prev[k] = ssn['previous']
+        act[k]  = k
+    for k in prev.keys():
+        p = lin.get(prev[k])
+        if p is not None:
+            eq_dict [lin[prev[k]]] = lin[k]
+            act_dict[lin[prev[k]]] = act[prev[k]]
+    return eq_dict, act_dict
+
 def get_bn_dict_from_supernodes(net):
     bn_dict = {}
     # check all supernodes for BN and CONV layers
-    for k,sn in net.graph.get_supernodes().items():
+    for k,ssn in net.graph.get_supernodes().items():
         bn = []
         lin = []
+        sn = ssn['supernode']
+        prev = ssn['previous']
         for n in sn:
             if isinstance(n[1], torch.nn.BatchNorm2d) or \
                isinstance(n[1], torch.nn.BatchNorm1d) or \

--- a/nemo/transf/common.py
+++ b/nemo/transf/common.py
@@ -38,7 +38,7 @@ def reshape_before(m, s):
     elif m.__class__.__name__ == "PACT_Conv1d":
         return s.reshape((s.shape[0],1,1))
     elif m.__class__.__name__ == "PACT_Linear":
-        return s.reshape((1,s.shape[0]))
+        return s.reshape((s.shape[0],1))
     else:
         return s
 
@@ -52,7 +52,7 @@ def reshape_after(m, s):
     elif m.__class__.__name__ == "PACT_Conv1d":
         return s.reshape((1,s.shape[0],1))
     elif m.__class__.__name__ == "PACT_Linear":
-        return s.reshape((s.shape[0],1))
+        return s.reshape((1,s.shape[0]))
     else:
         return s
 

--- a/nemo/transf/deploy.py
+++ b/nemo/transf/deploy.py
@@ -58,7 +58,9 @@ def _set_deployment_pact(self, eps_in, only_activations=False, **kwargs):
 
     """
 
+    self.stage = 'qd'
     if not only_activations:
+        self.eps_in = eps_in
         self.set_eps_in(eps_in)
     for n,m in self.named_modules():
         if ((not only_activations and m.__class__.__name__ == "PACT_QuantizedBatchNorm2d") or \

--- a/nemo/transf/statistics.py
+++ b/nemo/transf/statistics.py
@@ -30,6 +30,19 @@ import math
 import torchvision.models
 import re
 from nemo.transf.common import *
+from contextlib import contextmanager
+
+@contextmanager
+def _statistics_act_pact(self):
+    r"""Used with `with net.statistics_act():`, calls `net.set_statistics_act()` on enter
+    and `net.unset_statistics_act()` on exit.    
+
+    """
+    self.set_statistics_act()
+    try:
+        yield
+    finally:
+        self.unset_statistics_act()
 
 def _set_statistics_act_pact(self):
     r"""Sets :py:class:`nemo.quant.PACT_Act` layers to collect statistics and work like ReLU's.

--- a/nemo/transf/utils.py
+++ b/nemo/transf/utils.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 
 import torch
+import nemo
 from nemo.precision import Precision
 from nemo.quant.pact import *
 from nemo.graph import DeployGraph
@@ -151,3 +152,21 @@ def _reset_alpha_weights_pact(self, **kwargs):
             m.__class__.__name__ == "PACT_Conv1d" or \
             m.__class__.__name__ == "PACT_Linear"):
             m.reset_alpha_weights(**kwargs)
+
+def _qd_stage(self, eps_in=None, add_input_bias_dict={}, remove_bias_dict={}, **kwargs):
+    self.harden_weights()
+    if add_input_bias_dict:
+        self.add_input_bias(add_input_bias_dict)
+    if remove_bias_dict:
+        self.remove_bias(remove_bias_dict)
+    nemo.transform.bn_quantizer(self, **kwargs)
+    self.set_deployment(eps_in=eps_in)
+
+def _id_stage(self, eps_in=None, **kwargs):
+    if self.stage == 'fq':
+        self.qd_stage(eps_in=eps_in, **kwargs)
+    self.stage = 'id'
+    if eps_in is None:
+        eps_in = self.eps_in
+    nemo.transform.integerize_pact(self, eps_in=eps_in)
+

--- a/nemo/transform.py
+++ b/nemo/transform.py
@@ -151,13 +151,14 @@ def _hier_bn_to_identity(module):
         return module
 
 def _hier_bn_quantizer(module, **kwargs):
-    if module.__class__.__name__ == 'BatchNorm2d':# or \
-    #    module.__class__.__name__ == 'BatchNorm1d':
+    if module.__class__.__name__ == 'BatchNorm2d' or \
+        module.__class__.__name__ == 'BatchNorm1d':
         gamma = module.weight.data[:].clone().detach()
         beta = module.bias.data[:].clone().detach()
         sigma = torch.sqrt(module.running_var.data[:] + module.eps).clone().detach()
         mu = module.running_mean.data[:].clone().detach()
-        module = PACT_QuantizedBatchNorm2d(kappa=gamma/sigma, lamda=beta-gamma/sigma*mu, **kwargs)
+        dimensions = 1 if module.__class__.__name__ == 'BatchNorm1d' else 2
+        module = PACT_QuantizedBatchNorm2d(kappa=gamma/sigma, lamda=beta-gamma/sigma*mu, dimensions=dimensions, **kwargs)
         return module
     else:
         for n,m in module.named_children():

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pytorch-nemo",
-    version="0.0.2",
+    version="0.0.3",
     author="Francesco Conti",
     author_email="f.conti@unibo.it",
     description="NEural Minimizer for pytOrch",

--- a/tests/mnist_test.py
+++ b/tests/mnist_test.py
@@ -242,7 +242,7 @@ assert acc >= 98.8
 
 """Notice a small reduction in accuracy: as you might remember, the batch-norm layers were not quantized before folding; folding absorbs them inside the quantized parameters. Therefore a small reduction is expected! There are also a few techniques that can be used to recover accuracy, such as the weight equaliztion for Data Free Quantization proposed by Nagel et al. (https://arxiv.org/abs/1906.04721) . Here we try it on our network, which requires also a new calibration pass."""
 
-model.equalize_weights_dfq({'conv1':'conv2'})
+model.equalize_weights_dfq({'conv1':'conv2'}, reset_alpha=False)
 model.set_statistics_act()
 _ = test(model, device, test_loader)
 model.unset_statistics_act()


### PR DESCRIPTION
- Automatically derive DFQ equalization dict
- Consider also ConstantPad2d in bias removal
- Add convenience net.qd_stage and net.id_stage funcs
- Support BatchNorm1d in QD,ID (via PACT_*BatchNorm2d)
- Fix shape of reshape_before/after for PACT_Linear layers
- Add dropout_to_identity transform and related flag in quantize_pact
