### PR TITLE
v0.0.5

### DIFF
--- a/.github/requirements/1.3.1.txt
+++ b/.github/requirements/1.3.1.txt
@@ -3,3 +3,4 @@ torchvision>=0.4.1,<0.5.0
 numpy
 tqdm
 packaging
+scikit-learn

--- a/.github/requirements/1.4.0.txt
+++ b/.github/requirements/1.4.0.txt
@@ -3,3 +3,4 @@ torchvision>=0.5.0,<0.6.0
 numpy
 tqdm
 packaging
+scikit-learn

--- a/.github/requirements/1.5.0.txt
+++ b/.github/requirements/1.5.0.txt
@@ -3,3 +3,4 @@ torchvision>=0.6.0,<0.7.0
 numpy
 tqdm
 packaging
+scikit-learn

--- a/nemo/quant/pact.py
+++ b/nemo/quant/pact.py
@@ -424,7 +424,7 @@ class PACT_Act(torch.nn.Module):
 
         if self.deployment:
             x_rq = pact_quantized_requantize(x, self.eps_in, self.eps_static, self.D, exclude_requant_rounding=self.precise) * self.eps_static
-            return x_rq.clamp(0, self.alpha_static.data[0] - self.eps_static.data[0])
+            return x_rq.clamp(0, self.alpha_static.data[0])
         elif self.statistics_only:
             if self.leaky is None:
                 x = torch.nn.functional.relu(x)
@@ -438,7 +438,7 @@ class PACT_Act(torch.nn.Module):
             return x
         else:
             eps = self.alpha/(2.0**(self.precision.get_bits())-1)
-            return pact_quantize(x, eps, self.alpha)
+            return pact_quantize(x, eps, self.alpha + eps)
 
 class PACT_IntegerAdd(torch.nn.Module):
     r"""PACT (PArametrized Clipping acTivation) activation for integer images.

--- a/nemo/transf/deploy.py
+++ b/nemo/transf/deploy.py
@@ -111,10 +111,10 @@ def _set_eps_in_pact(self, eps_in):
             m.eps_in_list = eps_in_list
 
 def _qd_stage(self, eps_in=None, add_input_bias_dict={}, remove_bias_dict={}, prune_empty_bn=True, int_accurate=True, **kwargs):
-    self.round_weights()
-    self.harden_weights()
     if prune_empty_bn:
         self.prune_empty_bn(threshold=1e-9)
+    self.round_weights()
+    self.harden_weights()
     if add_input_bias_dict:
         self.add_input_bias(add_input_bias_dict)
     if remove_bias_dict:

--- a/nemo/transf/utils.py
+++ b/nemo/transf/utils.py
@@ -142,7 +142,7 @@ def _get_clip_parameters_pact(self):
         if name[-5:] == 'alpha':
             yield param
 
-def _reset_alpha_weights_pact(self, **kwargs):
+def _reset_alpha_weights_pact(self, method='standard', **kwargs):
     r"""Resets parameter `W_alpha`.
     
     """

--- a/nemo/transform.py
+++ b/nemo/transform.py
@@ -112,6 +112,7 @@ def quantize_pact(module, W_bits=4, x_bits=4, dummy_input=None, remove_dropout=F
     module.prune_empty_bn              = types.MethodType(nemo.transf.bn._prune_empty_bn_pact, module)
     module.get_eps_at                  = types.MethodType(nemo.transf.deploy._get_eps_at, module)
     module.set_eps_in                  = types.MethodType(nemo.transf.deploy._set_eps_in_pact, module)
+    module.round_weights               = types.MethodType(nemo.transf.deploy._round_weights_pact, module)
     module.harden_weights              = types.MethodType(nemo.transf.deploy._harden_weights_pact, module)
     module.set_deployment              = types.MethodType(nemo.transf.deploy._set_deployment_pact, module)
     module.qd_stage                    = types.MethodType(nemo.transf.deploy._qd_stage, module)

--- a/nemo/transform.py
+++ b/nemo/transform.py
@@ -127,6 +127,7 @@ def quantize_pact(module, W_bits=4, x_bits=4, dummy_input=None, remove_dropout=F
     module.unset_train_loop            = types.MethodType(nemo.transf.utils._unset_train_loop_pact, module)
     module.prune_weights               = types.MethodType(nemo.transf.pruning._prune_weights_pact, module)
     module.equalize_weights_dfq        = types.MethodType(nemo.transf.equalize._equalize_weights_dfq_pact, module)
+    module.equalize_weights_lsq        = types.MethodType(nemo.transf.equalize._equalize_weights_lsq_pact, module)
     module.equalize_weights_unfolding  = types.MethodType(nemo.transf.equalize._equalize_weights_unfolding_pact, module)
     module.statistics_act              = types.MethodType(nemo.transf.statistics._statistics_act_pact, module)
     module.set_statistics_act          = types.MethodType(nemo.transf.statistics._set_statistics_act_pact, module)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ torchvision>=0.4.1
 numpy
 tqdm
 packaging
+scikit-learn

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pytorch-nemo",
-    version="0.0.4",
+    version="0.0.5",
     author="Francesco Conti",
     author_email="f.conti@unibo.it",
     description="NEural Minimizer for pytOrch",
@@ -24,6 +24,7 @@ setuptools.setup(
         "torchvision>=0.4.1",
         "numpy",
         "tqdm",
-        "packaging"
+        "packaging",
+        "scikit-learn"
     ]
 )

--- a/tests/mnist_test.py
+++ b/tests/mnist_test.py
@@ -249,7 +249,7 @@ model.unset_statistics_act()
 model.reset_alpha_act()
 acc = test(model, device, test_loader)
 print("\nFakeQuantized @ mixed-precision (folded+equalized) accuracy: %.02f%%" % acc)
-assert acc >= 99.0
+assert acc >= 98.8
 
 """Now we go back one step, reloading the state from the saved checkpoint (before folding) to show the "standard" deployment strategy that we use, based on Integer Batch-Norm (Rusci et al., https://arxiv.org/abs/1905.13082). 
 This is organized in two steps: first, we replace all `BatchNorm2d` in the network into a special quantized form, which is equivalent to freezing their parameters and transforms them, essentially, in channel-wise affine transforms. Then, we harden weights in their current quantum representation. Finally, we use the `set_deployment` method to bring the network to the ***QuantizedDeployable*** stage.


### PR DESCRIPTION
v0.0.5 introduces new equalization strategies, and switches from floor-based to round-based quantization for weights. Notice this *breaks compatibility* with networks that were fine-tuned with quantization in previous versions. Compatibility is restored by subtracting eps/2 from all weights.