### PR TITLE
 Added pytorch version 1.6, updated the division operator and corrected the eps_out for pulp dronet

### DIFF
--- a/.github/requirements/1.6.0.txt
+++ b/.github/requirements/1.6.0.txt
@@ -1,0 +1,6 @@
+torch==1.6.0
+torchvision>=0.7.0,<0.8.0
+numpy
+tqdm
+packaging
+scikit-learn

--- a/.github/workflows/nemo.yml
+++ b/.github/workflows/nemo.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ "3.5" ]
-        torch-version: [ "1.3.1", "1.4.0", "1.5.0" ]
+        torch-version: [ "1.3.1", "1.4.0", "1.5.0", "1.6.0" ]
 
     steps:
     - uses: actions/checkout@v2.1.0

--- a/nemo/quant/pact.py
+++ b/nemo/quant/pact.py
@@ -489,6 +489,10 @@ class PACT_IntegerAdd(torch.nn.Module):
                 y += x[i]
             return y
         else:
+            if not hasattr(self, 'eps_out') and not hasattr(self, 'eps_in_list'):
+                print("[nemo-pact] ERROR! Trying to call forward on an Add for which eps_in's are not defined")
+            elif not hasattr(self, 'eps_out'):
+                self.get_output_eps(self.eps_in_list)
             return pact_integer_requantize_add(*x, eps_in_list=self.eps_in_list, eps_out=self.eps_out, D=self.D)
 
 class PACT_IntegerAvgPool2d(torch.nn.AvgPool2d):

--- a/nemo/quant/pact.py
+++ b/nemo/quant/pact.py
@@ -51,7 +51,7 @@ def pact_quantized_requantize(t, eps_in, eps_out, D=1, exclude_requant_rounding=
 def pact_integer_requantize(t, eps_in, eps_out, D=1):
     eps_ratio = (D*eps_in/eps_out).round()
     device = t.device
-    return torch.as_tensor((torch.as_tensor(t, dtype=torch.int64) * torch.as_tensor(eps_ratio, dtype=torch.int64) / torch.as_tensor(D, dtype=torch.int64)), dtype=torch.float32, device=device)
+    return torch.as_tensor((torch.as_tensor(t, dtype=torch.int64) * torch.as_tensor(eps_ratio, dtype=torch.int64) // torch.as_tensor(D, dtype=torch.int64)), dtype=torch.float32, device=device)
 
 # re-quantize from a lower precision (larger eps_in) to a higher precision (lower eps_out)
 def pact_integer_requantize_add(*t, eps_in_list, eps_out, D=1):

--- a/nemo/utils.py
+++ b/nemo/utils.py
@@ -229,14 +229,14 @@ def get_summary(net, input_size, batch_size=1, device="cuda", verbose=False):
         )
         total_params += summary[layer]["nb_params"]
         try:
-            params_size += abs(summary[layer]["nb_params"] // (1024) * summary[layer]["W_bits"] / 8.)
+            params_size += abs(summary[layer]["nb_params"]  * summary[layer]["W_bits"] / 8. / (1024.))
         except KeyError:
-            params_size += abs(summary[layer]["nb_params"] // (1024) * 32. / 8.)
+            params_size += abs(summary[layer]["nb_params"] * 32. / 8. / (1024.))
         total_output += np.prod(summary[layer]["output_shape"])
         try:
-            output_size = max(output_size, np.prod(summary[layer]["output_shape"]) // (1024) * summary[layer]["bits"] / 8)
+            output_size = max(output_size, np.prod(summary[layer]["output_shape"]) * summary[layer]["bits"] / 8 / (1024.))
         except KeyError:
-            output_size = max(output_size, np.prod(summary[layer]["output_shape"]) // (1024) * 32 / 8)
+            output_size = max(output_size, np.prod(summary[layer]["output_shape"]) * 32 / 8 / (1024.))
         if "trainable" in summary[layer]:
             if summary[layer]["trainable"] == True:
                 trainable_params += summary[layer]["nb_params"]
@@ -247,8 +247,8 @@ def get_summary(net, input_size, batch_size=1, device="cuda", verbose=False):
     s += "Trainable params: {0:,}".format(trainable_params) + "\n"
     s += "Non-trainable params: {0:,}".format(total_params - trainable_params) + "\n"
     s += "----------------------------------------------------------------" + "\n"
-    s += "Biggest activation tensor size (kB): %0.2f" % output_size + "\n"
-    s += "Params size (kB): %0.2f" % params_size + "\n"
+    s += "Biggest activation tensor size (kB): {0:,.2f}".format(output_size) + "\n"
+    s += "Params size (kB): {0:,.1f}".format(params_size) + "\n"
     s += "----------------------------------------------------------------" + "\n"
     if verbose:
         logging.info(s)

--- a/nemo/utils.py
+++ b/nemo/utils.py
@@ -229,14 +229,14 @@ def get_summary(net, input_size, batch_size=1, device="cuda", verbose=False):
         )
         total_params += summary[layer]["nb_params"]
         try:
-            params_size += abs(summary[layer]["nb_params"] / (1024) * summary[layer]["W_bits"] / 8.)
+            params_size += abs(summary[layer]["nb_params"] // (1024) * summary[layer]["W_bits"] / 8.)
         except KeyError:
-            params_size += abs(summary[layer]["nb_params"] / (1024) * 32. / 8.)
+            params_size += abs(summary[layer]["nb_params"] // (1024) * 32. / 8.)
         total_output += np.prod(summary[layer]["output_shape"])
         try:
-            output_size = max(output_size, np.prod(summary[layer]["output_shape"]) / (1024) * summary[layer]["bits"] / 8)
+            output_size = max(output_size, np.prod(summary[layer]["output_shape"]) // (1024) * summary[layer]["bits"] / 8)
         except KeyError:
-            output_size = max(output_size, np.prod(summary[layer]["output_shape"]) / (1024) * 32 / 8)
+            output_size = max(output_size, np.prod(summary[layer]["output_shape"]) // (1024) * 32 / 8)
         if "trainable" in summary[layer]:
             if summary[layer]["trainable"] == True:
                 trainable_params += summary[layer]["nb_params"]


### PR DESCRIPTION
added  torch-version: [ "1.3.1", "1.4.0", "1.5.0", "1.6.0" ]
updated all the division operators from "/" to "//".
For cpomputing statistics in the "summary" function, I converted the approximated "/" integer division to a floting point division for better accuracy (for calculating the number of parameters)

I also added the modification in the pact.py file that we did for accomodating the pulp dronet model (solving the "eps_out" missing)
