### PR TITLE
2 bugs fixed + minor fixes

### DIFF
--- a/nemo/graph.py
+++ b/nemo/graph.py
@@ -262,7 +262,8 @@ class DeployGraph(object):
                     break
             if type(eps) is float:
                 eps_list.append(torch.tensor(eps))
-            eps_list.append(eps)
+            else:
+                eps_list.append(eps)
         if len(eps_list) == 1:
             return eps_list[0]
         else:

--- a/nemo/transf/deploy.py
+++ b/nemo/transf/deploy.py
@@ -106,9 +106,9 @@ def _set_eps_in_pact(self, eps_in):
             if eps_in_new is None:
                 continue
         if (m.__class__.__name__ == "PACT_Act"):
-            m.eps_in = torch.tensor(eps_in_new[0], requires_grad=False)
+            m.eps_in = eps_in_new[0].clone().detach().requires_grad_(False)
         if (m.__class__.__name__ == "PACT_QuantizedBatchNormNd"):
-            m.eps_in = torch.tensor(eps_in_new[0], requires_grad=False)
+            m.eps_in = eps_in_new[0].clone().detach().requires_grad_(False)
         if (m.__class__.__name__ == "PACT_IntegerAdd"):
             eps_in_list = []
             for eps in eps_in_new:


### PR DESCRIPTION
I fixed 2 bugs:
1. sometimes, the eps_in gets a value that is a torch tensor + a normal number. It was lacking of an "else" clause in the code
2. Fixed the overflow in the pact_integerAdd by limiting the precision to 7 bits for each beanch

Minors:
- changed torch.as_tensor with .clone().detach()